### PR TITLE
認可処理の実装

### DIFF
--- a/src/main/java/oit/is37/security/controller/Sample31Controller.java
+++ b/src/main/java/oit/is37/security/controller/Sample31Controller.java
@@ -1,0 +1,59 @@
+package oit.is37.security.controller;
+
+import java.security.Principal;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+
+
+/**
+ * /sample3へのリクエストを扱うクラス authenticateの設定をしていれば， /sample3へのアクセスはすべて認証が必要になる
+ */
+@Controller
+@RequestMapping("/sample3")
+public class Sample31Controller {
+
+
+  @GetMapping("step1")
+  public String sample31() {
+    return "sample31.html";
+  }
+
+  @GetMapping("step3")
+  public String sample33() {
+    return "sample33.html";
+  }
+
+  @GetMapping("step7")
+  public String sample37() {
+    return "sample37.html";
+  }
+
+  /**
+   *
+   * @param model Thymeleafにわたすデータを保持するオブジェクト
+   * @param prin  ログインユーザ情報が保持されるオブジェクト
+   * @return
+   */
+  @GetMapping("step2")
+  public String sample32(ModelMap model, Principal prin) {
+    String loginUser = prin.getName(); // ログインユーザ情報
+    model.addAttribute("login_user", loginUser);
+    return "sample31.html";
+  }
+
+  @PostMapping("step6")
+  public String sample36(@RequestParam Integer hiku1, @RequestParam Integer hiku2, ModelMap model) {
+    int kekka = hiku1 - hiku2;
+    model.addAttribute("hikukekka", kekka);
+    return "sample33.html";
+  }
+
+
+}

--- a/src/main/java/oit/is37/security/security/Sample3AuthConfiguration.java
+++ b/src/main/java/oit/is37/security/security/Sample3AuthConfiguration.java
@@ -1,0 +1,73 @@
+package oit.is37.security.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+public class Sample3AuthConfiguration {
+  /**
+   * 認可処理に関する設定（認証されたユーザがどこにアクセスできるか）
+   *
+   * @param http
+   * @return
+   * @throws Exception
+   */
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.formLogin(login -> login
+        .permitAll())
+        .logout(logout -> logout
+            .logoutUrl("/logout")
+            .logoutSuccessUrl("/")) // ログアウト後に / にリダイレクト
+        .authorizeHttpRequests(authz -> authz
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/sample3/**"))
+            .authenticated() // /sample3/以下は認証済みであること
+            .requestMatchers(AntPathRequestMatcher.antMatcher("/**"))
+            .permitAll())// 上記以外は全員アクセス可能
+        .csrf(csrf -> csrf
+            .ignoringRequestMatchers(AntPathRequestMatcher.antMatcher("/h2-console/*")))// h2-console用にCSRF対策を無効化
+        .headers(headers -> headers
+            .frameOptions(frameOptions -> frameOptions
+                .sameOrigin()));
+    return http.build();
+  }
+
+  /**
+   * 認証処理に関する設定（誰がどのようなロールでログインできるか）
+   *
+   * @return
+   */
+  @Bean
+  public InMemoryUserDetailsManager userDetailsService() {
+
+    // ユーザ名，パスワード，ロールを指定してbuildする
+    // このときパスワードはBCryptでハッシュ化されているため，{bcrypt}とつける
+    // ハッシュ化せずに平文でパスワードを指定する場合は{noop}をつける
+
+    UserDetails user1 = User.withUsername("user1")
+        .password("{bcrypt}$2y$05$VA0TwC44qL5fgjxZgJvZMeG6CPq5BzyXetglYZNm.6qiCCYbfemQq").roles("USER").build();
+    UserDetails user2 = User.withUsername("user2")
+        .password("{bcrypt}$2y$10$ngxCDmuVK1TaGchiYQfJ1OAKkd64IH6skGsNw1sLabrTICOHPxC0e").roles("USER").build();
+    UserDetails user3 = User.withUsername("user3")
+        .password("{bcrypt}$2y$05$y9Bxnty4CkxwCSidyn6tXumwLqNt6H4F5ZqvLmdiczjHIjv4etSnu").roles("USER").build();
+    UserDetails e1b22036 = User.withUsername("e1b22036")
+        .password("{bcrypt}$2y$05$tFXzBY1ZXalY17cdgmFrLuAdOcZD3u.d743UovcXedCojt8bdQUjK").roles("ADMIN").build();
+
+    UserDetails e1b22017 = User.withUsername("e1b22017")
+        .password("{bcrypt}$2y$05$37dr0z/mmfg05kYkbFdNqOINnHWbaS4cRCiIPqOZdOrB7ydbDaa36").roles("USER").build();
+
+    UserDetails admin = User.withUsername("admin")
+        .password("{bcrypt}$2y$10$ngxCDmuVK1TaGchiYQfJ1OAKkd64IH6skGsNw1sLabrTICOHPxC0e").roles("ADMIN").build();
+
+    // 生成したユーザをImMemoryUserDetailsManagerに渡す（いくつでも良い）
+    return new InMemoryUserDetailsManager(user1, user2, admin, e1b22036, e1b22017, user3);
+  }
+}

--- a/src/main/resources/templates/sample31.html
+++ b/src/main/resources/templates/sample31.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>SpringBoot Sample3-1</title>
+</head>
+
+<body>
+  <h1>Authorized! [[${login_user}]]</h1>
+  <a href="/logout">ログアウト</a>
+
+  <p>
+    <a href="/sample3/step2">ログインユーザ名をGETで取得(Sample3-2)</a>
+  </p>
+
+  <p>
+    <a href="/sample3/step3">Sample3-3へGETで移動</a>
+  </p>
+
+
+</body>
+
+</html>

--- a/src/main/resources/templates/sample33.html
+++ b/src/main/resources/templates/sample33.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.springframework.org/schema/security">
+
+<head>
+  <meta charset="utf-8">
+  <title>SpringBoot Sample3-3</title>
+</head>
+
+<body>
+  <div><a href="/logout">ログアウト</a></div>
+
+  <h2>ユーザ名とロール名の表示(Sample3-4)</h2>
+  java上でPrinciplesから値を取得する方法ではなく，thymeleaf-extras-springsecurityプラグインを利用してhtmlから直接ユーザ名やPrinciples（ロール情報）を取得する方法を試す．
+  <!--sec:authenticationで認証情報にアクセスできる．nameはユーザ名を表す-->
+  <h3>ユーザ名：<div sec:authentication="name"></div>
+  </h3>
+  <!--sec:authenticationで認証情報にアクセスできる．principal.authoritiesはロール名を表す-->
+  <h3>ロール名：<div sec:authentication="principal.authorities"></div>
+  </h3>
+  <h2>ロールごとの表示情報の切り分け(Sample3-5)</h2>
+  hasRoleを使うと，そのタグをログインユーザのロールごとに表示する/しないを切り分けることができる
+  <div sec:authorize="hasRole('ROLE_ADMIN')">
+    <span>あなたは管理者ですね</span>
+  </div>
+
+  <div sec:authorize="hasRole('ROLE_USER')">
+    <div>あなたはユーザですね．</div>
+  </div>
+  <div>引き算を実行しましょう(Sample3-6)．</div>
+  <!--
+      認証処理を伴う場合はform action=ではなく，thを使ったthymeleafの記述を利用する必要がある(CSRF対応のため)
+    -->
+  <form th:action="@{/sample3/step6}" method="post">
+    <input type="number" name="hiku1" />-
+    <input type="number" name="hiku2" />
+    <input type="submit" value="計算"><input type="reset" value="リセット">
+  </form>
+  <div th:if="${hikukekka}">
+    結果：[[${hikukekka}]]
+  </div>
+  </div>
+
+
+  <p>
+    <a href=" /sample3/step7">Sample3-7へGETで移動</a>
+  </p>
+
+
+</body>
+
+</html>


### PR DESCRIPTION
任意のユーザIDとパスワードのユーザを2名分追加
3つの認可に伴う処理をSample3AuthConfiguration.javaに実装すること
SpringSecurityのフォームを利用する
/sample3 で始まるURLへのアクセス時にのみ認証を必要とする (例：http://localhost:8080/sample3/hoge)
ログアウト時にはトップページ (http://localhost:8080/)に戻る